### PR TITLE
Add ntp to the servers so the times are up to date between them.

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - apt: pkg={{ item }} state=latest
   with_items:
+    - ntp
     - vim
     - git
     - tar


### PR DESCRIPTION
Found during deployment:

```
[2014-10-09 02:48:16]  ** [out :: 10.0.1.4] tar: 20141009014804/vendor/autoload.php: time stamp 2014-10-09 02:48:14 is 6.503790157 s in the future
```

Installing `ntp` updates the date and time on the VMs so they're synchronised properly.
