### PR TITLE
Upgrade vagrant environment to use wheezy

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,38 +16,37 @@ SCRIPT
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+	# A apt-get cache plugin for vagrant can be installed via http://fgrehm.viewdocs.io/vagrant-cachier
+	config.vm.box = "debian_wheezy_7_8"
+	config.vm.box_url = "http://tools.silverstripe.com/vagrant/debian_wheezy_7_8_minimal.box"
 
-    config.vm.box = "debian_squeeze_6_0_3"
-    config.vm.box_url = "http://tools.silverstripe.com/vagrant/squeeze.box"
-    # A apt-get cache plugin for vagrant can be installed via http://fgrehm.viewdocs.io/vagrant-cachier
-
-    config.vm.provider "virtualbox" do |v|
+	config.vm.provider "virtualbox" do |v|
 		v.memory = 512
 		v.cpus = 1
-    end
-    
-    config.vm.define "deploynaut" do |deploynaut|
-        deploynaut.vm.hostname = "deploynaut"
-        deploynaut.vm.network "private_network", ip: "10.0.1.2"
-        deploynaut.vm.network "forwarded_port", guest: 80, host: 8102
-        deploynaut.vm.network "forwarded_port", guest: 5678, host: 5678
+	end
+
+	config.vm.define "deploynaut" do |deploynaut|
+		deploynaut.vm.hostname = "deploynaut"
+		deploynaut.vm.network "private_network", ip: "10.0.1.2"
+		deploynaut.vm.network "forwarded_port", guest: 80, host: 8102
+		deploynaut.vm.network "forwarded_port", guest: 5678, host: 5678
 		deploynaut.vm.synced_folder "../", "/sites/mysite/www", owner: "www-data", group: "www-data"
 		deploynaut.vm.provision "ansible", playbook: "node_deploynaut.yml"
-    end
+	end
 
-    config.vm.define "uat" do |uat|
-        uat.vm.hostname = "uat"
-        uat.vm.network "private_network", ip: "10.0.1.3"
-        uat.vm.network "forwarded_port", guest: 80, host: 8103
+	config.vm.define "uat" do |uat|
+		uat.vm.hostname = "uat"
+		uat.vm.network "private_network", ip: "10.0.1.3"
+		uat.vm.network "forwarded_port", guest: 80, host: 8103
 		uat.vm.provision "ansible", playbook: "node_web.yml"
-    end
+	end
 
-    config.vm.define "prod" do |prod|
-        prod.vm.hostname = "prod"
-        prod.vm.network "private_network", ip: "10.0.1.4"
-        prod.vm.network "forwarded_port", guest: 80, host: 8104
+	config.vm.define "prod" do |prod|
+		prod.vm.hostname = "prod"
+		prod.vm.network "private_network", ip: "10.0.1.4"
+		prod.vm.network "forwarded_port", guest: 80, host: 8104
 		prod.vm.provision "ansible", playbook: "node_web.yml"
-    end
+	end
 
 	config.vm.define "rep1" do |rep1|
 		rep1.vm.hostname = "rep1"

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -6,8 +6,10 @@
     - vim
     - git
     - tar
+    - curl
     - apache2
     - php5
+    - python-software-properties
 
 - name: install apache modules
   apache2_module: state=present name={{ item }}
@@ -74,4 +76,3 @@
 
 - name: download sspak
   get_url: url=http://silverstripe.github.io/sspak/sspak.phar dest=/usr/bin/sspak mode=0777
-

--- a/roles/deploynaut/tasks/main.yml
+++ b/roles/deploynaut/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: install ruby and rediss
   apt: pkg={{ item }} state=latest
   with_items:
-    - ruby1.8
+    - ruby
     - redis-server
 
 - name: install gem capistrano
@@ -21,7 +21,7 @@
   gem: name=resque state=present user_install=no
 
 - name: symlink gem binaries to /usr/bin
-  file: state=link src=/var/lib/gems/1.8/bin/{{ item }} dest=/usr/bin/{{ item }}
+  file: state=link src=/usr/local/bin/{{ item }} dest=/usr/bin/{{ item }}
   with_items:
     - cap
     - capify

--- a/roles/ha/tasks/main.yml
+++ b/roles/ha/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Install new apt sources for Galera.
-- apt_repository: repo='deb http://mirror.aarnet.edu.au/pub/MariaDB/repo/5.5/debian squeeze main' state=present
-- apt_repository: repo='deb-src http://mirror.aarnet.edu.au/pub/MariaDB/repo/5.5/debian squeeze main' state=present
+- apt_repository: repo='deb http://mirror.aarnet.edu.au/pub/MariaDB/repo/5.5/debian wheezy main' state=present
+- apt_repository: repo='deb-src http://mirror.aarnet.edu.au/pub/MariaDB/repo/5.5/debian wheezy main' state=present
 - apt_key: url=http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xcbcb082a1bb943db
 # Note: we use mysqldump for SST, xtrabackup-v2 throws cryptic errors - so commenting out for now.
 #- apt_repository: repo='deb http://repo.percona.com/apt squeeze main' state=present


### PR DESCRIPTION
Mostly came out of the fact some Ruby gems didn't work on the Ruby
version distributed with squeeze, and that's now two versions behind
the current Debian, so upgrading to wheezy seemed worthwhile. :-)

I didn't upgrade to Jessie because the MariaDB packages don't have
any support for the current Debian version yet.

On a side note, MariaDB 10.0 seemed to work fine in a clustered state,
but I've intentionally left it at 5.5, since we only support the previous stable version.